### PR TITLE
Chore: Add the request source to the headers

### DIFF
--- a/volue_insight_timeseries/auth.py
+++ b/volue_insight_timeseries/auth.py
@@ -5,6 +5,7 @@
 import json
 import time
 import threading
+import os
 
 try:
     from urllib.parse import urljoin
@@ -59,6 +60,12 @@ class OAuth:
 
     def get_headers(self, data):
         """The web-token auth header is simple"""
+        headers = {}
         if self.token is not None and self.token_type is not None:
-            return {'Authorization': '{} {}'.format(self.token_type, self.token)}
-        return {}
+            headers['Authorization'] = '{} {}'.format(self.token_type, self.token)
+        
+        wapi_request_source = os.getenv('WAPI_REQUEST_SOURCE')
+        if wapi_request_source:
+            headers['X-Request-Source'] = wapi_request_source
+            
+        return headers


### PR DESCRIPTION
Add a new header to the request so that they identify themselves in the same way as requests from wapi-python-extension. This is done to keep track of where the load on wapi is coming from. 