### PR TITLE
chore: add pip caching to speedup unit-test workflow runs

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,6 +28,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.libraries-versions }}-${{ hashFiles('**/requirements.txt', '**/test-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.libraries-versions }}-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
       - name: Install dependencies ${{ matrix.python-version }}
         run: |
           REQS="-r requirements.txt -r test-requirements.txt"


### PR DESCRIPTION
- trying to fix the unit-test taking over 10m to run on py3.12 with pandas, numpy combo