### PR TITLE
Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://api.volueinsight.com/ (or equivalent services). Note that access
 is based on having a valid Volue Insight account. Please contact
 sales.insight@volue.com in order to get a trial account.
 
-The library is tested against Python 3.9, 3.10, 3.11 and 3.12 - we recommend using 
+The library is tested against Python 3.9, 3.10, 3.11, 3.12 and 3.13 - we recommend using 
 the latest Python version.
 
 
@@ -54,7 +54,7 @@ the event of a severe bug that we will do any changes to it.
 These are the steps you will have to do in order to successfully
 make the switch. 
 
-* Use Python 3.9, 3.10, 3.11 or 3.12
+* Use Python 3.9, 3.10, 3.11, 3.12 or 3.13
 * Use Pandas 1.5.0 or newer
 * Use [zoneinfo](https://docs.python.org/3/library/zoneinfo.html), not pytz for handling time zone information
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(os.path.join(here, 'volue_insight_timeseries/VERSION')) as fv:
 
 setup(
     name='volue_insight_timeseries',
-    python_requires='>=3.9, <3.13a0',
+    python_requires='>=3.9, <3.14',
     packages=find_packages(),
     install_requires=extract_requirements('requirements.txt'),
     tests_require=[


### PR DESCRIPTION
It would be useful if `volue-insight-timeseries` would support Python 3.13.

Python 3.13 was released nearly a year ago, and the new Debian stable (Trixie) uses it. I have not observed any differences when using `volue-insight-timeseries` with Python 3.12 and 3.13.