### PR TITLE
build: Adding support for Python 3.13

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,8 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10' , '3.11', '3.12']
-        libraries-versions: [ 'pandas==1.5.2 "numpy<2.0"', 'pandas>=2.2.0']
+        python-version: [ '3.10' , '3.11', '3.12', '3.13' ]
+        libraries-versions: [ 'pandas==1.5.2 "numpy<2.0"', 'pandas==2.2.2', 'pandas>=2.2.3' ]
+        exclude:
+          - python-version: '3.13'
+            libraries-versions: 'pandas==1.5.2 "numpy<2.0"'
+          - python-version: '3.13'
+            libraries-versions: 'pandas==2.2.2'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/Dockerfile-release
+++ b/Dockerfile-release
@@ -1,3 +1,3 @@
-FROM python:3.9
+FROM python:3.10
 
 RUN pip install -U twine

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ https://api.volueinsight.com/ (or equivalent services). Note that access
 is based on having a valid Volue Insight account. Please contact
 sales.insight@volue.com in order to get a trial account.
 
-The library is tested against Python 3.9, 3.10, 3.11 and 3.12 - we recommend using 
-the latest Python version.
+The library is tested against Python 3.10, 3.11, 3.12 and 3.13. Please only use either of these python versions.
 
 
 ## Documentation
@@ -54,8 +53,8 @@ the event of a severe bug that we will do any changes to it.
 These are the steps you will have to do in order to successfully
 make the switch. 
 
-* Use Python 3.9, 3.10, 3.11 or 3.12
-* Use Pandas 1.5.0 or newer
+* Use Python 3.10, 3.11, 3.12 or 3.13
+* Use Pandas 1.5.0 or newer for python 3.10-3.12. Use Pandas 2.2.3 or newer for python 3.13 or newer
 * Use [zoneinfo](https://docs.python.org/3/library/zoneinfo.html), not pytz for handling time zone information
 
 ### Example of migrating an existing script
@@ -64,7 +63,7 @@ highlight things that are changing, not a recommended way to write production
 code.
 
 ```python
-# python 3.9.8
+# python 3.10.18
 # pip install wapi-python==0.7.15
 # pip install python-dotenv==1.0.1
 #
@@ -98,7 +97,7 @@ if results:
 The migrated script is below
 
 ```python
-# python 3.9.8
+# python 3.10.18
 # pip install volue-insight-timeseries==1.2.0
 # pip install python-dotenv==1.0.1
 #

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@ Installation
 ============
 
 To use the Volue Insight API python library you need to have `Python`_ installed.
-The library is tested against for python version 3.9, 3.10, 3.11 and 3.12. 
+The library is tested against for python version 3.10, 3.11, 3.12 and 3.13.
 Please only use either of these python versions.
 
 You can simply install/update the latest version of Volue Insight API python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.18
 sseclient-py>=1.7
-pandas>=1.5.0
+pandas>=1.5.0; python_version >= "3.10" and python_version < "3.13"
+pandas>=2.3.2; python_version >= "3.13"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(os.path.join(here, 'volue_insight_timeseries/VERSION')) as fv:
 
 setup(
     name='volue_insight_timeseries',
-    python_requires='>=3.9, <3.13a0',
+    python_requires='>=3.10, <=3.13',
     packages=find_packages(),
     install_requires=extract_requirements('requirements.txt'),
     tests_require=[

--- a/volue_insight_timeseries/events.py
+++ b/volue_insight_timeseries/events.py
@@ -32,7 +32,7 @@ class EventListener:
         self.queue = queue.Queue()
         self.do_shutdown = False
         self.worker = threading.Thread(target=self.fetch_events)
-        self.worker.setDaemon(True)
+        self.worker.daemon = True
         self.worker.start()
 
     def get(self):


### PR DESCRIPTION
Change list:

- Adding support for Python 3.13;
- Dropping support for Python 3.9;
- Extend unit test to cover python 3.13;
- Removed deprecated calls;
- Update docs.