### PR TITLE
fix: fix false positives on warning 

### DIFF
--- a/volue_insight_timeseries/util.py
+++ b/volue_insight_timeseries/util.py
@@ -155,11 +155,7 @@ class TS(object):
         # Gas Day is a 24-hour period starting at 4:00 UTC in summer and 5:00 UTC in winter, 
         # and finishing at 4:00 UTC (or 5:00) the next day. corresponding to 6:00 local time in Germany year-round.
         # A gas loader bug causes timestamps on the day after DST to shift to 5:00 or 7:00 instead of 6:00.
-        number_of_nan = 0
-        for point in self.points:
-            if point[1] is None:
-                number_of_nan += 1
-
+        number_of_nan = sum(1 for point in self.points if point[1] is None)
         if len(self.points) -  number_of_nan  != len(dropped):
             warnings.warn(
                 f"Data length mismatch: original data length is {len(self.points)}, but mapped frequency data length is "


### PR DESCRIPTION
Users of volue_insight_timeseries might encounter this RuntimeWarning about a mismatch of data length when using the `.to_pandas()` method on a TS object. It seems like this happens even though the length of the points list in the TS object and the returned Series from to_pandas() are equal.

It seems like the function is doing the wrong comparison. We are comparing the size cleaned pandas.Series with the size of uncleaned TS.points. (cleaned in this context means removing entries with NaN values)

The alternative would be to determine how many NaN points are inside the TS.points and then do the comparison len(cleanedSeries) == (len(TS.points) - number_of_NaN)

The issue is that we will have to iterate over all the elements inside the TS.points which could be up to 1 million points in worst case scenario.
I tested on my machine with some randomly generated data and it takes 0.03 seconds to iterate over 1M points and do a comparison and increment a value on each iteration. This could vary depending on the machine, but is should not be a big overhear. And did some testing with the actual change on my local machine and these are the results:

**for ~14.5k points, to_pandas takes around 0.04780316352844238 seconds with the check for nans in to_pandas()**
**for ~14.5k points, to_pandas takes around 0.04129409790039062 seconds without the check for nans in to_pandas()**

**for ~730k points, to_pandas takes around 1.7758846282958984 seconds with the check for nans in to_pandas()**
**for ~730k points, to_pandas takes around 1.6412301063537598 seconds without the check for nans in to_pandas()**

(I mean let's be real,  using python does not scream "I care about performance"), and the assumption for applications where performance is critical customers will do requests directly to the API and do their own transformations on the data.

The alternative is to just remove this function since the number of false positives is probably multiple orders of magnitude greater than the number of correct hits, and at that point customers/internal users will just suppress/ignore the warning anyway.

the last option to do nothing about it since it is not breaking anything, but it is probably annoying to deal with.
