### PR TITLE
ci: make codeql run on pushes/PRs to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "development" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "development" ]
+    branches: [ "main" ]
 
 jobs:
   analyze:


### PR DESCRIPTION
Change the codeql workflow to  run on pushes and PRs to main instead of the old development branch.