### PR TITLE
fix: specify release tag prefix

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           bump_version_scheme: ${{ github.event.inputs.version_bump }}
           use_github_release_notes: true
+          tag_prefix: ""


### PR DESCRIPTION
Specify the release tag prefix to be an empty string to override the default "v".
The action has been releasing version `v0.0.1` instead of `2.0.2`. The suspicion is that it has been looking for the latests release that is prefixed with "v" but there aren't any, so it starts from the beginning which is v0.0.1